### PR TITLE
fix: update Docker repository name to rikasai/md

### DIFF
--- a/scripts/build-multiarch.sh
+++ b/scripts/build-multiarch.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 RELEASE_DIR="./docker"
-REPO_NAME="doocs/md"
+REPO_NAME="rikasai/md"
 PLATFORMS="linux/amd64,linux/arm64"
 
 echo "🔧 Multi-arch Docker build started..."


### PR DESCRIPTION
## Summary
- Update REPO_NAME in build-multiarch.sh from doocs/md to rikasai/md
- This fixes the Docker push access denied error in GitHub Actions workflow

## Test plan
- [x] Verify build script syntax is correct
- [ ] Test Docker workflow execution after merge

🤖 Generated with [Claude Code](https://claude.ai/code)