### PR TITLE
fix: complete Docker repository updates to rikasai/md

### DIFF
--- a/docker/latest/Dockerfile.base
+++ b/docker/latest/Dockerfile.base
@@ -3,7 +3,7 @@ ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US.UTF-8"
 ENV LC_ALL="en_US.UTF-8"
 RUN apk add --no-cache curl unzip
-RUN curl -L "https://github.com/doocs/md/archive/refs/heads/main.zip" -o "main.zip" && unzip "main.zip" && mv "md-main" /app
+RUN curl -L "https://github.com/lihuacai168/md/archive/refs/heads/main.zip" -o "main.zip" && unzip "main.zip" && mv "md-main" /app
 WORKDIR /app
 COPY ./patch/vite.config.ts /app/vite.config.ts
 ENV NODE_OPTIONS="--openssl-legacy-provider"

--- a/docker/latest/Dockerfile.nginx
+++ b/docker/latest/Dockerfile.nginx
@@ -1,6 +1,6 @@
 ARG VER_NGX="1.21.6-alpine"
 
-FROM --platform=$BUILDPLATFORM doocs/md:latest-assets AS assets
+FROM --platform=$BUILDPLATFORM rikasai/md:latest-assets AS assets
 FROM --platform=$TARGETPLATFORM nginx:${VER_NGX}
 LABEL MAINTAINER="ylb<contact@yanglibin.info>"
 COPY --from=assets /app/assets /usr/share/nginx/html

--- a/docker/latest/Dockerfile.standalone
+++ b/docker/latest/Dockerfile.standalone
@@ -1,7 +1,7 @@
 ARG VER_GOLANG=1.17.6-alpine3.15
 ARG VER_ALPINE=3.15
 
-FROM --platform=$BUILDPLATFORM "doocs/md:latest-assets" AS assets
+FROM --platform=$BUILDPLATFORM "rikasai/md:latest-assets" AS assets
 
 FROM --platform=$BUILDPLATFORM "golang:$VER_GOLANG" AS gobuilder
 ARG TARGETARCH

--- a/docker/latest/Dockerfile.static
+++ b/docker/latest/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM doocs/md:latest-assets AS assets
+FROM --platform=$BUILDPLATFORM rikasai/md:latest-assets AS assets
 
 # detail https://github.com/lipanski/docker-static-website/blob/master/Dockerfile
 FROM --platform=$TARGETPLATFORM lipanski/docker-static-website

--- a/scripts/build-base-image.sh
+++ b/scripts/build-base-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RELEASE_DIR='./docker';
-REPO_NAME='doocs/md'
+REPO_NAME='rikasai/md'
 
 for app_ver in $RELEASE_DIR/*; do
 

--- a/scripts/build-nginx.sh
+++ b/scripts/build-nginx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RELEASE_DIR='./docker';
-REPO_NAME='doocs/md'
+REPO_NAME='rikasai/md'
 
 for app_ver in $RELEASE_DIR/*; do
 

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RELEASE_DIR='./docker';
-REPO_NAME='doocs/md'
+REPO_NAME='rikasai/md'
 
 for app_ver in $RELEASE_DIR/*; do
 

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RELEASE_DIR='./docker';
-REPO_NAME='doocs/md'
+REPO_NAME='rikasai/md'
 
 for app_ver in $RELEASE_DIR/*; do
 

--- a/scripts/push-images.sh
+++ b/scripts/push-images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RELEASE_DIR='./docker';
-REPO_NAME='doocs/md'
+REPO_NAME='rikasai/md'
 
 for app_ver in $RELEASE_DIR/*; do
 


### PR DESCRIPTION
## Summary
- Update REPO_NAME in all build scripts to use rikasai/md instead of doocs/md
- Update FROM statements in all Docker files to use rikasai/md:latest-assets
- Update GitHub source URL in Dockerfile.base to download from lihuacai168/md repository
- This fixes the Docker push access denied error by ensuring all images are pushed to the correct repository

## Changes Made
- **Build Scripts**: Updated 5 build scripts (build-standalone.sh, build-nginx.sh, build-static.sh, build-base-image.sh, push-images.sh)
- **Docker Files**: Updated 4 Docker files (Dockerfile.standalone, Dockerfile.static, Dockerfile.nginx, Dockerfile.base)
- **GitHub URL**: Updated source repository URL in Dockerfile.base

## Test plan
- [x] Verify all build scripts reference rikasai/md
- [x] Verify all Docker files reference rikasai/md:latest-assets
- [x] Verify GitHub source URL points to lihuacai168/md
- [ ] Test Docker workflow execution after merge

🤖 Generated with [Claude Code](https://claude.ai/code)